### PR TITLE
Fix some return types

### DIFF
--- a/libs/ppm_io.cpp
+++ b/libs/ppm_io.cpp
@@ -111,7 +111,7 @@ int PPM::write(const std::string & filepath) const
     return 0;
 }
 
-int PPM::load(const uint8_t * buffer, const int h, const int w, const int max, const std::string magic)
+void PPM::load(const uint8_t * buffer, const int h, const int w, const int max, const std::string magic)
 {
     mH = h;
     mW = w;

--- a/libs/ppm_io.cpp
+++ b/libs/ppm_io.cpp
@@ -178,6 +178,7 @@ PPM & PPM::operator = (const PPM & ppm)
     int max = ppm.getMax();
     uint8_t * buffer = ppm.getImageHandler();
     load(buffer, h, w, max, magic);
+    return *this;
 }
 
 bool PPM::operator == (const PPM & ppm) const

--- a/libs/ppm_io.h
+++ b/libs/ppm_io.h
@@ -26,7 +26,7 @@ public:
     // Save PPM to file
     int write(const std::string & filepath) const;
     // Load array as PPM
-    int load(const uint8_t * buffer, const int h, const int w, const int max, const std::string magic);
+    void load(const uint8_t * buffer, const int h, const int w, const int max, const std::string magic);
     // Get attributes
     std::string getMagic() const;
     std::string getFilepath() const;


### PR DESCRIPTION
- `load` was declared as `int load` but did not return a value. This caused segmentation fault.
- copy assignment operator did not return *this.